### PR TITLE
remove nightly feature req

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-#![feature(bigint_helper_methods)]
-
 use bitcoin::script::write_scriptint;
 use clap::Parser;
 use fast_merkle::Tree;


### PR DESCRIPTION
We no longer need bigint helper methods, remove the feature check.

Fixes #15 